### PR TITLE
make Rule constructor public

### DIFF
--- a/src/main/java/ch/poole/openinghoursparser/Rule.java
+++ b/src/main/java/ch/poole/openinghoursparser/Rule.java
@@ -53,7 +53,7 @@ public class Rule extends Element {
     /**
      * Default constructor
      */
-    Rule() {
+    public Rule() {
         // empty
     }
 


### PR DESCRIPTION
Currently to build an empty Rule object I need to use following as a workaround:

```
        ByteArrayInputStream input = new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
        OpeningHoursParser parser = new OpeningHoursParser(input);
        Rule emptyRule;
        try {
            ArrayList<Rule> rules = parser.rules(true);
            emptyRule = rules.get(0);
        } catch (ParseException e) {
            e.printStackTrace();
            throw new RuntimeException();
        }
```

To avoid XY problem: I want an empty Rule object as I want to check whatever given opening_hours object is using certain subset of opening hours syntax. To do this I

- create an empty `Rule` object
- add to this empty rule only constructs known to be supported, copying them from the original rule
- compare whatever it equals original one

Alternative solution would be to check for all constructs known to be unsupported on the Rule object, but I think that it is far more likely to fail due to missing something.