### PR TITLE
Support four digit times in non-strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is a very simplistic parser for string values according to the [OSM opening hours specification][opening-hours-specification]. It is used in a number of OpenStreetMap projects, for example
 in [Vespucci](https://github.com/MarcusWolschon/osmeditor4android). As the opening hours specification is currently reasonably stable you shouldn't expect lots of activity in this repository.
 
-It parses 147'189 (91%) of 161'268 unique test strings in non-strict mode. The remaining 14'079 are likely valid errors, spot checking shows that they have obvious issues. In strict mode a further 15'993 fail (total 30'072).
+It parses 147'628 (92%) of 161'268 unique test strings in non-strict mode. The remaining 13'640 are likely valid errors, spot checking shows that they have obvious issues. In strict mode a further 16'432 fail (total 30'072).
 
 Deviations from the grammar as of [this version of the opening hours specification][opening-hours-grammar-specification] in all modes:
 
@@ -24,6 +24,7 @@ In non-strict mode the following further differences are allowed:
  * ignore spaces and more than one leading zeros in minutes
  * "." and "h" as minutes separators
  * AM and PM time specifications are allowed (plus A.M. and P.M.) 
+ * 4 digit times in some circumstances
  * holidays in weekday range
  * superfluous ":" after weekday range
  * 24/7 rules with preceding selectors are corrected to 00:00-24:00 time spans

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ updateTranslations.description = 'Update translations by executing the transifex
 task showDifferences(type: JavaExec) {
     main = "ch.poole.openinghoursparser.Diff"
     classpath = sourceSets.test.runtimeClasspath
-    args('test-data/oh.txt-result', 'test-data/oh.txt-result-temp', 'test-data/oh.txt', 'test-data/diff.txt')
+    args('test-data/oh.txt-result.ocs', 'test-data/oh.txt-result-temp', 'test-data/oh.txt', 'test-data/diff.txt')
 }
 showDifferences.group = 'verification'
 showDifferences.description = "Extract differences between reference test results and current results"
@@ -105,7 +105,7 @@ showDifferences.description = "Extract differences between reference test result
 task showDifferencesStrict(type: JavaExec) {
     main = "ch.poole.openinghoursparser.Diff"
     classpath = sourceSets.test.runtimeClasspath
-    args('test-data/oh.txt-result-strict', 'test-data/oh.txt-result-strict-temp', 'test-data/oh.txt', 'test-data/diff-strict.txt')
+    args('test-data/oh.txt-result-strict.ocs', 'test-data/oh.txt-result-strict-temp', 'test-data/oh.txt', 'test-data/diff-strict.txt')
 }
 showDifferencesStrict.group = 'verification'
 showDifferencesStrict.description = "Extract differences between reference test results and current results in strict mode"

--- a/src/main/java/ch/poole/openinghoursparser/OpeningHoursParser.jj
+++ b/src/main/java/ch/poole/openinghoursparser/OpeningHoursParser.jj
@@ -47,10 +47,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Collections;
 import java.util.Locale;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-
-import ch.poole.openinghoursparser.Util;
 
 import static ch.poole.openinghoursparser.I18n.tr;
 
@@ -390,30 +386,42 @@ int time() :
 {
   Token h = null;
   Token m = null;
+  Token t = null;
   int result = 0;
   AMPM ampm = null;
 }
 {
   (
-    h = hours()
+    // 4 digit times: years have to be >= 1900, so we can avoid conflicts by only fixing up things that are smaller than that    LOOKAHEAD({ getToken(1).image.length() == 4 && getToken(1).kind == NUMBER && Util.between(getToken(1).image, 0, 1859) && Util.between(getToken(1).image.substring(2), 0, 59)})
+    t = < NUMBER >
+  |
+    (
+      (
+        h = hours()
+      )
+      (
+        LOOKAHEAD(minutes(), { h!=null })
+        m = minutes()
+      )?
+    )
   )
-  (
-    LOOKAHEAD(minutes(), { h!=null })
-    m = minutes()
-  )?
   (
     ampm = ampm()
   )?
   {
-    if (strict && m == null) {
-        ParseException pex = new OpeningHoursParseException(tr("hours_without_minutes"));
+    if (strict && (t != null || m == null)) {
+        ParseException pex = new OpeningHoursParseException(tr(t == null ? "hours_without_minutes" : "four_digit_time_value"));
 	    pex.currentToken = token;
         throw pex;
     }
-    if (m != null) {
-      result = Integer.parseInt(m.image);
+    if (t != null) {
+        result = Integer.parseInt(t.image.substring(2)) + Integer.parseInt(t.image.substring(0,2)) * 60;
+    } else { 
+        if (m != null) {
+            result = Integer.parseInt(m.image);
+        }
+        result = result + Integer.parseInt(h.image) * 60;
     }
-    result = result + Integer.parseInt(h.image) * 60;
     if (ampm == AMPM.PM && result < TWELVEHOURS) { // only use add 12h if the time is less than 12 h
       result = result + TWELVEHOURS;               // 12:01 pm to 12:59 pm are already correct 24h times
     } else if (ampm == AMPM.AM && result >= TWELVEHOURS && result < TWELVEHOURS + 60) {
@@ -458,31 +466,44 @@ int extendedtime() :
 {
   Token h = null;
   Token m = null;
+  Token t = null;
   int result = 0;
   AMPM ampm = null;
 }
 {
   (
-    LOOKAHEAD({ getToken(1).kind == NUMBER && Util.between(getToken(1).image, 0, 48) })
-    h = < NUMBER >
+    // 4 digit time value
+    LOOKAHEAD({ getToken(1).image.length() == 4 && getToken(1).kind == NUMBER && Util.between(getToken(1).image, 0, 4800) && Util.between(getToken(1).image.substring(2), 0, 59)}) 
+    t = < NUMBER >
+  |
+    (  
+      (
+        LOOKAHEAD({ getToken(1).kind == NUMBER && Util.between(getToken(1).image, 0, 48) })
+        h = < NUMBER >
+      )
+      (
+        LOOKAHEAD(minutes(), { h!=null })
+        m = minutes()
+      )?
+    )
   )
-  (
-    LOOKAHEAD(minutes(), { h!=null })
-    m = minutes()
-  )?
   (
     ampm = ampm()
   )?
   {
-    if (strict && m == null) {
-        ParseException pex = new OpeningHoursParseException(tr("hours_without_minutes"));
+    if (strict && (t != null || m == null)) {
+        ParseException pex = new OpeningHoursParseException(tr(t == null ? "hours_without_minutes" : "four_digit_time_value"));
         pex.currentToken = token;
         throw pex;
     }
-    if (m != null) {
-      result = Integer.parseInt(m.image);
+    if (t != null) {
+      result = Integer.parseInt(t.image.substring(2)) + Integer.parseInt(t.image.substring(0,2)) * 60;
+    } else { 
+      if (m != null) {
+        result = Integer.parseInt(m.image);
+      }
+      result = result + Integer.parseInt(h.image) * 60;
     }
-    result = result + Integer.parseInt(h.image) * 60;
     if (ampm == AMPM.PM && result < TWELVEHOURS) {
       result = result + TWELVEHOURS;
     } else if (ampm == AMPM.AM && result >= TWELVEHOURS && result < TWELVEHOURS + 60) {

--- a/src/main/resources/ch/poole/openinghoursparser/Messages.properties
+++ b/src/main/resources/ch/poole/openinghoursparser/Messages.properties
@@ -7,6 +7,7 @@ exception_expecting = Was expecting: {0}
 found = {0} found
 holiday_in_weekday_range = Holiday in weekday range
 hours_without_minutes = Hours without minutes
+four_digit_time_value = Four digit time value
 interval_not_allowed_here = Interval not allowed here
 invalid_event = {0} is not a valid event
 invalid_minutes = Invalid minutes

--- a/src/test/resources/ch/poole/openinghoursparser/Messages_de.properties
+++ b/src/test/resources/ch/poole/openinghoursparser/Messages_de.properties
@@ -7,6 +7,7 @@ exception_expecting = Erwartet wurde: {0}
 found = {0} gefunden
 holiday_in_weekday_range = Feiertag in Wochentagbereich
 hours_without_minutes = Stunden ohne Minuten
+four_digit_time_value = Vierstelliger Zeitwert
 interval_not_allowed_here = Intervalle sind hier nicht erlaubt
 invalid_event = {0} ist kein gültiger Ereigniswert
 invalid_minutes = Ungültiger Minutenwert


### PR DESCRIPTION
This adds support for parsing 4 digit time values when they don't
conflict with year values. That is the first time in a time rage is <
1900.