### PR TITLE
Add open ended to year range

### DIFF
--- a/src/main/java/ch/poole/openinghoursparser/OpeningHoursParser.jj
+++ b/src/main/java/ch/poole/openinghoursparser/OpeningHoursParser.jj
@@ -360,7 +360,9 @@ Token minutes() :
   Token m = null;
 }
 {
-  (      (      (delimiter =  < COLON > ) | (delimiter = < STOP > ) | (delimiter= < H >)
+  (  
+    (
+      (delimiter =  < COLON > ) | (delimiter = < STOP > ) | (delimiter= < H >)
     )
     LOOKAHEAD({ getToken(1).kind == NUMBER && Util.between(getToken(1).image, 0, 59) && (getToken(1).image.length() >= 2 || "0".equals(getToken(1).image))})
     m = < NUMBER >
@@ -1204,10 +1206,16 @@ YearRange year_range() :
   YearRange yr = new YearRange();
   Token y = null;
   Token y1 = null;
+  Token plus = null;
   Token to = null;
 }
 {
-  yr.startYear = year()
+  ( 
+    yr.startYear = year() (plus = < PLUS >)?
+  )
+  {
+    yr.openEnded = plus != null;
+  } 
   (
     (
       < HYPHEN > | (to = < TO >)

--- a/src/main/java/ch/poole/openinghoursparser/OpeningHoursParser.jj
+++ b/src/main/java/ch/poole/openinghoursparser/OpeningHoursParser.jj
@@ -1210,31 +1210,35 @@ YearRange year_range() :
   Token to = null;
 }
 {
-  ( 
-    yr.startYear = year() (plus = < PLUS >)?
-  )
-  {
-    yr.openEnded = plus != null;
-  } 
   (
+    ( 
+      yr.startYear = year()
+    ) 
     (
-      < HYPHEN > | (to = < TO >)
-    )
-    (
-      yr.endYear = year()
-    )
-    {
-      if (strict && to != null) {
-        throw new OpeningHoursParseException(tr("to_instead_of_dash"), token.next);
-      }
-    }
-    (
-      yr.interval = interval()
+      plus = < PLUS >
+      |
+      (
+        (
+          < HYPHEN > | (to = < TO >)
+        )
+        (
+          yr.endYear = year()
+        )
+        {
+          if (strict && to != null) {
+            throw new OpeningHoursParseException(tr("to_instead_of_dash"), token.next);
+          }
+        }
+        (
+          yr.interval = interval()
+        )?
+      )
     )?
-  )?
-  {
-    return yr;
-  }
+    {
+      yr.openEnded = plus != null;
+      return yr;
+    }
+  )
 }
 
 

--- a/src/main/java/ch/poole/openinghoursparser/YearRange.java
+++ b/src/main/java/ch/poole/openinghoursparser/YearRange.java
@@ -37,9 +37,11 @@ public class YearRange extends Element {
      * one day
      */
     public static final int UNDEFINED_YEAR   = Integer.MIN_VALUE;
-    int                     startYear        = UNDEFINED_YEAR;
-    int                     endYear          = UNDEFINED_YEAR;
-    int                     interval         = 0;
+    
+    boolean openEnded           = false;
+    int     startYear           = UNDEFINED_YEAR;
+    int     endYear             = UNDEFINED_YEAR;
+    int     interval            = 0;
 
     /**
      * Default constructor
@@ -54,6 +56,7 @@ public class YearRange extends Element {
      * @param yr original YearRange
      */
     public YearRange(@NotNull YearRange yr) {
+        openEnded = yr.openEnded;
         startYear = yr.startYear;
         endYear = yr.endYear;
         interval = yr.interval;
@@ -63,6 +66,9 @@ public class YearRange extends Element {
     public String toString() {
         StringBuilder b = new StringBuilder();
         b.append(String.format(Locale.US, "%04d", startYear));
+        if (openEnded) {
+            b.append("+");
+        }
         if (endYear != UNDEFINED_YEAR) {
             b.append("-");
             b.append(String.format(Locale.US, "%04d", endYear));
@@ -81,7 +87,7 @@ public class YearRange extends Element {
         }
         if (other instanceof YearRange) {
             YearRange o = (YearRange) other;
-            if (startYear == o.startYear && endYear == o.endYear && interval == o.interval) {
+            if (startYear == o.startYear && endYear == o.endYear && interval == o.interval && openEnded == o.openEnded) {
                 return true;
             }
         }
@@ -91,10 +97,19 @@ public class YearRange extends Element {
     @Override
     public int hashCode() {
         int result = 1;
+        result = 37 * result + (openEnded ? 0 : 1);
         result = 37 * result + startYear;
         result = 37 * result + endYear;
         result = 37 * result + interval;
         return result;
+    }
+
+    
+    /**
+     * @return the openEnded
+     */
+    public boolean isOpenEnded() {
+        return openEnded;
     }
 
     /**
@@ -116,6 +131,13 @@ public class YearRange extends Element {
      */
     public int getInterval() {
         return interval;
+    }
+
+    /**
+     * @param openEnded the openEnded to set
+     */
+    public void setOpenEnded(boolean openEnded) {
+        this.openEnded = openEnded;
     }
 
     /**


### PR DESCRIPTION
I have added open ended to year range, for OH tags like "2021+". I have also made parser fail on "2021+-2022" or "2021-2022+", since the grammar permits only open ended for year range with start only. See [year_range](https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#year_range)