### PR TITLE
Fix open ended date parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: "jacoco"
 
-version = '0.26.0'
+version = '0.27.0'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/ch/poole/openinghoursparser/OpeningHoursParser.jj
+++ b/src/main/java/ch/poole/openinghoursparser/OpeningHoursParser.jj
@@ -1064,6 +1064,8 @@ DateWithOffset datewithoffset(boolean mo) :
         )
       )
       (
+        // This tries to, as lax as possible, differentiate between Jan 31+ Mo and Jan 31+Mo, that is an open ended date vs date with an offset  
+        LOOKAHEAD(5, ( < HYPHEN > | < PLUS > ) < WEEKDAY >, { getToken(1).kind == HYPHEN || !precedingWs(getToken(2)) || getToken(5).kind == DAYS }) 
         (
           minus = < HYPHEN >
         | < PLUS >

--- a/src/test/java/ch/poole/openinghoursparser/IndividualTest.java
+++ b/src/test/java/ch/poole/openinghoursparser/IndividualTest.java
@@ -5,27 +5,30 @@ import java.util.List;
 import java.util.Scanner;
 
 /**
- * Individual testing for the OpeningHoursParser, receiving
- * inputs from System.in
+ * Individual testing for the OpeningHoursParser, receiving inputs from System.in
  * 
  * 
  * @author Vuong Ho
  *
  */
-
 public class IndividualTest {
     public static void main(String[] args) {
-        Scanner sc = new Scanner(System.in); 
+        Scanner sc = new Scanner(System.in);
         Boolean isStrict = args[0].equals("true");
-        while(true) {
+        System.out.println("Parse strings in opening-hours format, empty input will terminate");
+        while (true) {
             System.out.print("Please enter your input: ");
             String input = sc.nextLine();
+            if ("".equals(input)) {
+                break;
+            }
             try {
                 OpeningHoursParser parser = new OpeningHoursParser(new ByteArrayInputStream(input.getBytes()));
                 List<ch.poole.openinghoursparser.Rule> rules = parser.rules(isStrict);
                 System.out.println("Legal input string");
                 System.out.println("Detected rules in input string listed below");
-                for(ch.poole.openinghoursparser.Rule rule : rules) {
+                System.out.println("\n------------------------------\n");
+                for (ch.poole.openinghoursparser.Rule rule : rules) {
                     System.out.println(rule.toDebugString());
                 }
                 System.out.println("\n------------------------------\n");

--- a/src/test/java/ch/poole/openinghoursparser/UnitTest.java
+++ b/src/test/java/ch/poole/openinghoursparser/UnitTest.java
@@ -299,6 +299,20 @@ public class UnitTest {
     }
 
     @Test
+    public void openEndedDateRange() {
+        OpeningHoursParser parser = new OpeningHoursParser(new ByteArrayInputStream("Jan 31+ Mo".getBytes()));
+        try {
+            List<Rule> rules = parser.rules(false);
+            assertEquals(1, rules.size());
+            List<DateRange> dateRanges = rules.get(0).getDates();
+            assertEquals(1, dateRanges.size());
+            assertTrue(dateRanges.get(0).getStartDate().isOpenEnded());
+        } catch (ParseException pex) {
+            fail(pex.getMessage());
+        }
+    }
+
+    @Test
     /**
      * This doesn't seem to turn up in our test data
      */


### PR DESCRIPTION
This addresses an ambiguity when parsing open ended data rages, for example Jan 3+ Mon that was being parsed as a date with weekday offset.

Fixes https://github.com/simonpoole/OpeningHoursFragment/issues/56