### PR TITLE
Add `Automatic-Module-Name` for JPMS compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,12 @@ jacocoTestReport {
     }
 }
 
+jar {
+    manifest {
+        attributes("Automatic-Module-Name": "ch.poole.openinghoursparser")
+    }
+}
+
 sonarqube {
     properties {
         property "sonar.java.source","1.8"


### PR DESCRIPTION
I've been going through JOSM's dependencies and adding `Automatic-Module-Name` or `module-info.java` where applicable.

Pros of `Automatic-Module-Name`: We don't have to fiddle with the build system. Maven was easy; I've hit some road blocks with gradle. I _think_ it is mostly related to having generated sources.
Cons of `Automatic-Module-Name`: It doesn't allow a project to hide internal packages, but that doesn't matter for this case, since everything is in the same package.

Sample `module-info.java` file:
```#!java
module ch.poole.openinghoursparser {
    requires static transitive org.jetbrains.annotations;
    exports ch.poole.openinghoursparser;
}
```